### PR TITLE
Remove redundant default exports

### DIFF
--- a/src/app/pages/dashboard/dashboard.component.ts
+++ b/src/app/pages/dashboard/dashboard.component.ts
@@ -24,4 +24,3 @@ import { MatIconModule } from '@angular/material/icon';
 export class DashboardComponent {
 
 }
-export { DashboardComponent as default };

--- a/src/app/pages/trade/trade.component.ts
+++ b/src/app/pages/trade/trade.component.ts
@@ -9,4 +9,3 @@ import { Component } from '@angular/core';
 export class TradeComponent {
 
 }
-export { TradeComponent as default };


### PR DESCRIPTION
## Summary
- Remove superfluous default export statements from dashboard and trade components, leaving class exports only

## Testing
- `npm test` (fails: sh: 1: ng: not found)

------
https://chatgpt.com/codex/tasks/task_e_68b017c1e70c8331a9b188da071d8d39